### PR TITLE
Fix loading of imported objects for registered hooks

### DIFF
--- a/src/Resources/contao/classes/CookieHandler.php
+++ b/src/Resources/contao/classes/CookieHandler.php
@@ -168,7 +168,7 @@ class CookieHandler extends System
             return $this->{$strKey};
         }
 
-        return $this->objModel->{$strKey} ?? null;
+        return $this->objModel->{$strKey} ?? parent::__get($strKey);
     }
 
     /**

--- a/src/Resources/contao/classes/CookieHandler.php
+++ b/src/Resources/contao/classes/CookieHandler.php
@@ -38,7 +38,7 @@ use Contao\System;
  * @property string  $scriptConfig
  * @property boolean $published
  */
-class CookieHandler extends System
+class CookieHandler
 {
     /**
      * Position flag: Below the content within the body tag
@@ -145,13 +145,10 @@ class CookieHandler extends System
                 {
                     foreach ($GLOBALS['TL_HOOKS']['compileCookieType'] as $callback)
                     {
-                        $this->import($callback[0]);
-                        $this->{$callback[0]}->{$callback[1]}($objCookie->type, $this);
+                        System::importStatic($callback[0])->{$callback[1]}($objCookie->type, $this);
                     }
                 }
         }
-
-        parent::__construct();
     }
 
     /**
@@ -168,7 +165,7 @@ class CookieHandler extends System
             return $this->{$strKey};
         }
 
-        return $this->objModel->{$strKey} ?? parent::__get($strKey);
+        return $this->objModel->{$strKey} ?? null;
     }
 
     /**


### PR DESCRIPTION
If you register a Hook `compileCookieType` via service annotation, it cannot be loaded because the parent of the magic getter is not called!

Maybe it would be a better approach not to use system class inheritance at all?