### PR TITLE
Fix typos in the german language files.

### DIFF
--- a/src/Resources/contao/languages/de/explain.xlf
+++ b/src/Resources/contao/languages/de/explain.xlf
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="XPL.cookiebarVersion.1.1">
         <source>To create a new version, select the &lt;code&gt;checkbox&lt;/code&gt; for &lt;code&gt;Update version&lt;/code&gt; and then save the mask. The version is automatically incremented.</source>
-        <target>Um eine neue Version zu erstellen, wählen Sie die &lt;code&gt;Checkbox&lt;/code&gt; bei &lt;code&gt;Version aktualisieren&lt;/code&gt; und speichern Sie anschließend die Maske. Die Version wird austomatisch hochgezählt.</target>
+        <target>Um eine neue Version zu erstellen, wählen Sie die &lt;code&gt;Checkbox&lt;/code&gt; bei &lt;code&gt;Version aktualisieren&lt;/code&gt; und speichern Sie anschließend die Maske. Die Version wird automatisch hochgezählt.</target>
       </trans-unit>
 
       <trans-unit id="XPL.cookiebarScriptConfig.0.0">

--- a/src/Resources/contao/languages/de/tl_content.xlf
+++ b/src/Resources/contao/languages/de/tl_content.xlf
@@ -7,7 +7,7 @@
       </trans-unit>
       <trans-unit id="tl_content.prefillCookies.1">
         <source>Activates the already selected cookies when opening the cookie bar.</source>
-        <target>Aktiviert beim öffnen der Cookiebar die bereits gewählten Cookies.</target>
+        <target>Aktiviert beim Öffnen der Cookiebar die bereits gewählten Cookies.</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/contao/languages/de/tl_cookie.xlf
+++ b/src/Resources/contao/languages/de/tl_cookie.xlf
@@ -135,7 +135,7 @@
       </trans-unit>
       <trans-unit id="tl_cookie.sourceUrlParameter.1">
         <source>Define the load parameters of the source URL to be used.</source>
-        <target>Definieren Sie die zu verwedenden Lade-Parameter der Source URL.</target>
+        <target>Definieren Sie die zu verwendenden Lade-Parameter der Source URL.</target>
       </trans-unit>
       <trans-unit id="tl_cookie.scriptConfirmed.0">
         <source>Script (confirmed)</source>
@@ -247,7 +247,7 @@
       </trans-unit>
       <trans-unit id="tl_cookie.scriptConfig.1">
         <source>Enter further parameters here, which should be taken into account when loading the script.</source>
-        <target>Tragen Sie hier weitere Parameter ein, welche beim laden des Skriptes berücksichtigt werden sollen.</target>
+        <target>Tragen Sie hier weitere Parameter ein, welche beim Laden des Skriptes berücksichtigt werden sollen.</target>
       </trans-unit>
       <trans-unit id="tl_cookie.tokenConfig_xlabel">
         <source>Insert default token</source>

--- a/src/Resources/contao/languages/de/tl_cookie_group.xlf
+++ b/src/Resources/contao/languages/de/tl_cookie_group.xlf
@@ -11,7 +11,7 @@
       </trans-unit>
       <trans-unit id="tl_cookie_group.title.1">
         <source>Enter a group name here.</source>
-        <target>Geben Sie hier einen Gruppenname an.</target>
+        <target>Geben Sie hier einen Gruppennamen an.</target>
       </trans-unit>
       <trans-unit id="tl_cookie_group.description.0">
         <source>Description</source>
@@ -19,7 +19,7 @@
       </trans-unit>
       <trans-unit id="tl_cookie_group.description.1">
         <source>Describe the cookie group and its purpose.</source>
-        <target>Beschreiben Sie hier die Cookie-Gruppe und dessen Zweck.</target>
+        <target>Beschreiben Sie hier die Cookie-Gruppe und deren Zweck.</target>
       </trans-unit>
       <trans-unit id="tl_cookie_group.published.0">
         <source>Publish</source>

--- a/src/Resources/contao/languages/de/tl_cookiebar.xlf
+++ b/src/Resources/contao/languages/de/tl_cookiebar.xlf
@@ -166,7 +166,7 @@
       </trans-unit>
       <trans-unit id="tl_cookiebar.blocking.1">
         <source>Blocks the use of the site until the cookie bar has been used.</source>
-        <target>Blockiert das bedienen der Seite bis die Cookiebar bedient wurde.</target>
+        <target>Blockiert das Bedienen der Seite bis die Cookiebar bedient wurde.</target>
       </trans-unit>
       <trans-unit id="tl_cookiebar.position.0">
         <source>Position</source>

--- a/src/Resources/contao/languages/de/tl_module.xlf
+++ b/src/Resources/contao/languages/de/tl_module.xlf
@@ -27,7 +27,7 @@
       </trans-unit>
       <trans-unit id="tl_module.prefillCookies.1">
         <source>Activates the already selected cookies when opening the cookie bar.</source>
-        <target>Aktiviert beim öffnen der Cookiebar die bereits gewählten Cookies.</target>
+        <target>Aktiviert beim Öffnen der Cookiebar die bereits gewählten Cookies.</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/contao/languages/de/tl_page.xlf
+++ b/src/Resources/contao/languages/de/tl_page.xlf
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="tl_page.cookiebarBlocking.1">
         <source>Blocks the use of the site until the cookie bar has been used.</source>
-        <target>Blockiert das bedienen der Seite bis die Cookiebar bedient wurde.</target>
+        <target>Blockiert das Bedienen der Seite bis die Cookiebar bedient wurde.</target>
       </trans-unit>
       <trans-unit id="tl_page.cookiebarInfoUrls.0">
         <source>Info links</source>


### PR DESCRIPTION
I have found some small typos in the german language files.