### PR TITLE
Add the missing exclude flags in tl_page fields

### DIFF
--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -21,6 +21,7 @@ $GLOBALS['TL_DCA']['tl_page']['subpalettes']['overwriteCookiebarMeta'] = 'cookie
 $GLOBALS['TL_DCA']['tl_page']['fields']['activateCookiebar'] = array
 (
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['activateCookiebar'],
+    'exclude'                 => true,
     'inputType'               => 'checkbox',
     'eval'                    => array('tl_class'=>'w50', 'submitOnChange'=>true),
     'sql'                     => "char(1) NOT NULL default ''"
@@ -29,6 +30,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['activateCookiebar'] = array
 $GLOBALS['TL_DCA']['tl_page']['fields']['overwriteCookiebarMeta'] = array
 (
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['overwriteCookiebarMeta'],
+    'exclude'                 => true,
     'inputType'               => 'checkbox',
     'eval'                    => array('tl_class'=>'w50 m12', 'submitOnChange'=>true),
     'sql'                     => "char(1) NOT NULL default ''"
@@ -37,6 +39,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['overwriteCookiebarMeta'] = array
 $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarConfig'] = array
 (
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['cookiebarConfig'],
+    'exclude'                 => true,
     'inputType'               => 'select',
     'options_callback' => static function ()
     {
@@ -49,6 +52,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarConfig'] = array
 $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarDescription'] = array
 (
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['cookiebarDescription'],
+    'exclude'                 => true,
     'inputType'               => 'textarea',
     'eval'                    => array('rte'=>'tinyMCE', 'helpwizard'=>true, 'tl_class' => 'w50'),
     'explanation'             => 'insertTags',
@@ -58,6 +62,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarDescription'] = array
 $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarInfoDescription'] = array
 (
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['cookiebarInfoDescription'],
+    'exclude'                 => true,
     'inputType'               => 'textarea',
     'eval'                    => array('rte'=>'tinyMCE', 'helpwizard'=>true, 'tl_class' => 'w50'),
     'explanation'             => 'insertTags',
@@ -67,6 +72,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarInfoDescription'] = array
 $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarInfoUrls'] = array
 (
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['cookiebarInfoUrls'],
+    'exclude'                 => true,
     'inputType'               => 'pageTree',
     'foreignKey'              => 'tl_page.title',
     'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'tl_class'=>'w50 clr'),
@@ -77,6 +83,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarInfoUrls'] = array
 $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarExcludePages'] = array
 (
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['cookiebarExcludePages'],
+    'exclude'                 => true,
     'inputType'               => 'pageTree',
     'foreignKey'              => 'tl_page.title',
     'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'tl_class'=>'w50'),
@@ -87,6 +94,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarExcludePages'] = array
 $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarTemplate'] = array
 (
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['cookiebarTemplate'],
+    'exclude'                 => true,
     'inputType'               => 'select',
     'options_callback' => static function ()
     {
@@ -110,6 +118,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarButtonColorScheme'] = array
 $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarAlignment'] = array
 (
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['cookiebarAlignment'],
+    'exclude'                 => true,
     'inputType'               => 'select',
     'options'                 => array(
         'cc-top'             => 'align-top',
@@ -128,6 +137,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarAlignment'] = array
 $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebarBlocking'] = array
 (
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['cookiebarBlocking'],
+    'exclude'                 => true,
     'inputType'               => 'checkbox',
     'eval'                    => array('tl_class'=>'w50 m12'),
     'sql'                     => "char(1) NOT NULL default ''"


### PR DESCRIPTION
Without the `exclude` flags, it is not possible to control visibility of those fields for the backend users with limited permissions.