### PR TITLE
Regex, if the quotes in the template are escaped

### DIFF
--- a/src/EventListener/FrontendTemplateListener.php
+++ b/src/EventListener/FrontendTemplateListener.php
@@ -139,7 +139,7 @@ class FrontendTemplateListener
                         else
                         {
                             // Regex: Modify src attribute for iframes
-                            $frameRegex = "/<iframe([\s\S]*?)src=([\"'])(.*?)[\"']/i";
+                            $frameRegex = "/<iframe([\s\S]*?)src=([\\\\\"\']+)(.*?)[\\\\\"\']+/i";
 
                             // Get current src attribute
                             preg_match_all($frameRegex, $buffer, $matches);


### PR DESCRIPTION
In my case, I had a template, which creates dynamic JS code with YouTube iframes from PHP. The quotes in this template are escaped. So, I wrote a little modification of the regex, which should be useful for everyone.