### PR TITLE
Fix public access for hook methods

### DIFF
--- a/src/Resources/contao/classes/AbstractCookie.php
+++ b/src/Resources/contao/classes/AbstractCookie.php
@@ -70,7 +70,7 @@ abstract class AbstractCookie
      * @param int $mode
      * @param int $pos
      */
-    protected function addScript(string $strScript, int $mode = self::LOAD_CONFIRMED, int $pos = self::POS_BELOW): void
+    public function addScript(string $strScript, int $mode = self::LOAD_CONFIRMED, int $pos = self::POS_BELOW): void
     {
         $this->scripts[] = [
             'script'    => $strScript,
@@ -86,7 +86,7 @@ abstract class AbstractCookie
      * @param array|null $flags
      * @param int $mode
      */
-    protected function addResource(string $strSrc, array $flags=null, int $mode = self::LOAD_CONFIRMED): void
+    public function addResource(string $strSrc, array $flags=null, int $mode = self::LOAD_CONFIRMED): void
     {
         $this->resources[] = [
             'src'   => $strSrc,


### PR DESCRIPTION
Unfortunately there is a breaking change in version `1.10.0`, so I had to add a conflict section in my small extensions which suggest your extension (see: https://github.com/bwein-net/contao-bfv-elements/commit/1fa568cdf78a53cc78afa68a10449a924cdce7eb).

The methods for the hooks need to be `public`, this PR fixes this problem!

In my case, I still have to exchange the boolean for the method of `addScript` for the new constants, to be compatible again (see: https://github.com/bwein-net/contao-bfv-elements/commit/2ebe01b8dd9beb7d1c7a4802a0178d1b9dcdd5e8).