### PR TITLE
Respond with 400 instead of throwing an exception

### DIFF
--- a/src/Controller/CookiebarController.php
+++ b/src/Controller/CookiebarController.php
@@ -68,7 +68,7 @@ class CookiebarController extends AbstractController
         // Protect against XSS attacks
         if(!Validator::isUrl($strUrl))
         {
-            throw new \Exception('The redirect destination must be a valid URL.');
+            return new Response('The redirect destination must be a valid URL.', Response::HTTP_BAD_REQUEST);
         }
 
         /** @var FrontendTemplate $objTemplate */


### PR DESCRIPTION
Instead of throwing a basic `\Exception` I think it would be better to actually respond with a `400 Bad Request` status. Otherwise this exception will be logged by Sentry for example.