### PR TITLE
Introduce template blocks for blocker

### DIFF
--- a/src/Resources/contao/templates/cookiebar/ccb_element_blocker.html5
+++ b/src/Resources/contao/templates/cookiebar/ccb_element_blocker.html5
@@ -1,73 +1,79 @@
 <!DOCTYPE html>
 <html lang="<?= $this->language ?>">
 <head>
-    <meta name="robots" content="noindex,nofollow" />
-    <style>
-        .ccb-element-blocker {
-            font-size: 14px;
-            font-family: sans-serif;
-            text-align: center;
-            color: #6f6f6f;
-        }
-        .ccb-element-blocker .cc-icon {
-            position: relative;
-            width: 220px;
-            height: 110px;
-            margin: 0 auto 8px;
-        }
-        .ccb-element-blocker .cc-icon:after {
-            content: "";
-            position: absolute;
-            left: 0;
-            top: 0;
-            bottom: 0;
-            right: 0;
-            background-position: center center;
-            background-size: contain;
-            background-repeat: no-repeat;
-            background-image: url("/bundles/contaocookiebar/images/default.png");
-        }
-        .ccb-element-blocker .cc-icon.vimeo:after {
-            background-image: url("/bundles/contaocookiebar/images/vimeo.png");
-        }
-        .ccb-element-blocker .cc-icon.youtube:after {
-            background-image: url("/bundles/contaocookiebar/images/youtube.png");
-        }
-        .ccb-element-blocker .cc-icon.googlemaps:after {
-            background-image: url("/bundles/contaocookiebar/images/googlemaps.png");
-        }
-        .ccb-element-blocker .cc-icon.openstreetmap:after {
-            background-image: url("/bundles/contaocookiebar/images/openstreetmap.png");
-        }
-        .ccb-element-blocker .cc-title{
-            font-weight: bold;
-        }
-        .ccb-element-blocker .cc-btn{
-            display: inline-block;
-            cursor: pointer;
-            padding: 8px 14px;
-            font-size: 15px;
-            outline: 0 none;
-            border: 1px solid #cfcfcf;
-            border-radius: 4px;
-            color: #444;
-            background: #f5f5f5;
-        }
-        .ccb-element-blocker .cc-btn:hover{
-            background: #ececec;
-        }
-    </style>
-    <script>
-        if(parent.cookiebar.issetCookie(<?=$this->id?>)){
-            window.location.href = '<?=$this->redirect?>';
-        }
-    </script>
+    <?php $this->block('head'); ?>
+        <meta name="robots" content="noindex,nofollow" />
+        <style>
+            .ccb-element-blocker {
+                font-size: 14px;
+                font-family: sans-serif;
+                text-align: center;
+                color: #6f6f6f;
+            }
+            .ccb-element-blocker .cc-icon {
+                position: relative;
+                width: 220px;
+                height: 110px;
+                margin: 0 auto 8px;
+            }
+            .ccb-element-blocker .cc-icon:after {
+                content: "";
+                position: absolute;
+                left: 0;
+                top: 0;
+                bottom: 0;
+                right: 0;
+                background-position: center center;
+                background-size: contain;
+                background-repeat: no-repeat;
+                background-image: url("/bundles/contaocookiebar/images/default.png");
+            }
+            .ccb-element-blocker .cc-icon.vimeo:after {
+                background-image: url("/bundles/contaocookiebar/images/vimeo.png");
+            }
+            .ccb-element-blocker .cc-icon.youtube:after {
+                background-image: url("/bundles/contaocookiebar/images/youtube.png");
+            }
+            .ccb-element-blocker .cc-icon.googlemaps:after {
+                background-image: url("/bundles/contaocookiebar/images/googlemaps.png");
+            }
+            .ccb-element-blocker .cc-icon.openstreetmap:after {
+                background-image: url("/bundles/contaocookiebar/images/openstreetmap.png");
+            }
+            .ccb-element-blocker .cc-title{
+                font-weight: bold;
+            }
+            .ccb-element-blocker .cc-btn{
+                display: inline-block;
+                cursor: pointer;
+                padding: 8px 14px;
+                font-size: 15px;
+                outline: 0 none;
+                border: 1px solid #cfcfcf;
+                border-radius: 4px;
+                color: #444;
+                background: #f5f5f5;
+            }
+            .ccb-element-blocker .cc-btn:hover{
+                background: #ececec;
+            }
+        </style>
+        <script>
+            if(parent.cookiebar.issetCookie(<?=$this->id?>)){
+                window.location.href = '<?=$this->redirect?>';
+            }
+        </script>
+    <?php $this->endblock(); ?>
 </head>
 <body>
-    <div class="ccb-element-blocker <?=$this->type?>">
-        <div class="cc-icon <?=$this->iframeType?>"></div>
-        <div class="cc-title"><?=$this->title?></div>
-        <div class="cc-description"><?=$this->description?></div>
-        <button class="cc-btn" onclick="parent.cookiebar.unblock(window.frames.frameElement, <?=$this->id?>, '<?=$this->redirect?>')"><?=$this->acceptAndDisplayLabel?></button>
-    </div>
+    <?php $this->block('body'); ?>
+        <div class="ccb-element-blocker <?=$this->type?>">
+            <?php $this->block('blocker_content'); ?>
+                <div class="cc-icon <?=$this->iframeType?>"></div>
+                <div class="cc-title"><?=$this->title?></div>
+                <div class="cc-description"><?=$this->description?></div>
+                <button class="cc-btn" onclick="parent.cookiebar.unblock(window.frames.frameElement, <?=$this->id?>, '<?=$this->redirect?>')"><?=$this->acceptAndDisplayLabel?></button>
+            <?php $this->endblock(); ?>
+        </div>
+    <?php $this->endblock(); ?>
 </body>


### PR DESCRIPTION
In case someone wants to adjust the template (like here https://github.com/oveleon/contao-cookiebar/issues/98 for instance) it would be helpful if not the whole template needs to be replaced and instead you could do:

```php
<?php $this->extend('ccb_element_blocker'); ?>

<?php $this->block('blocker_content'); ?>
  <?php $this->parent(); ?>
  <div class="redirect-link">
    <a href="<?= $this->redirect ?>" target="_blank" rel="nofollow noopener noreferrer">…</a>
  </div>
<?php $this->endblock(); ?>
```