### PR TITLE
added data-nosnippet attribute to prevent Google from using the cookiebar content

### DIFF
--- a/src/Resources/contao/templates/cookiebar/cookiebar_default.html5
+++ b/src/Resources/contao/templates/cookiebar/cookiebar_default.html5
@@ -2,7 +2,7 @@
     $GLOBALS['TL_CSS'][] = 'bundles/contaocookiebar/styles/cookiebar_default.css|static';
 ?>
 <!-- indexer::stop -->
-<div <?=$this->cssID ? 'id="' . $this->cssID . '"' : ''?> class="contao-cookiebar<?=$this->class ? ' ' . $this->class : ''?>" role="complementary" aria-describedby="cookiebar-desc">
+<div <?=$this->cssID ? 'id="' . $this->cssID . '"' : ''?> class="contao-cookiebar<?=$this->class ? ' ' . $this->class : ''?>" role="complementary" aria-describedby="cookiebar-desc" data-nosnippet>
     <div class="cc-inner" aria-live="assertive" role="alert">
         <div id="cookiebar-desc" class="cc-head">
             <?php $this->block('header'); ?>

--- a/src/Resources/contao/templates/cookiebar/cookiebar_simple.html5
+++ b/src/Resources/contao/templates/cookiebar/cookiebar_simple.html5
@@ -2,7 +2,7 @@
 $GLOBALS['TL_CSS'][] = 'bundles/contaocookiebar/styles/cookiebar_simple.css|static';
 ?>
 <!-- indexer::stop -->
-<div <?=$this->cssID ? 'id="' . $this->cssID . '"' : ''?> class="contao-cookiebar<?=$this->class ? ' ' . $this->class : ''?>" role="complementary" aria-describedby="cookiebar-desc">
+<div <?=$this->cssID ? 'id="' . $this->cssID . '"' : ''?> class="contao-cookiebar<?=$this->class ? ' ' . $this->class : ''?>" role="complementary" aria-describedby="cookiebar-desc" data-nosnippet>
     <div class="cc-inner" aria-live="assertive" role="alert">
         <div id="cookiebar-desc" class="cc-head">
             <?php $this->block('header'); ?>


### PR DESCRIPTION
Aktuell kann es passieren, dass der vom Cookiebot generierte Inhalt auch in den Suchergebnissen von Google landet. Als Demonstration kann man bei Google z. B. folgendes in die Suche eingeben: `site:oveleon.de cookie` - in diesem Fall natürlich extra mit dem Keyword provoziert, aber im schlimmsten Fall könnte der Text auch bei anderen Suchanfragen angezeigt werden.

Um dem vorzubeugen, sollte - ähnlich wie der Ausschluss der div-Container für die Contao-eigene Suche - auch das [data-nosnippet-Attribut](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=de#data-nosnippet-attr) gesetzt werden.

Wenn gewünscht, kann ich den Pull-Request auch noch für die 5er-Version erstellen.