### PR TITLE
Make the block URL of an iframe a relative path

### DIFF
--- a/src/EventListener/FrontendTemplateListener.php
+++ b/src/EventListener/FrontendTemplateListener.php
@@ -122,7 +122,7 @@ class FrontendTemplateListener
                 {
                     if(isset($cookie['iframeType']) && $cookie['iframeType'] === $strType)
                     {
-                        $strBlockUrl = '/cookiebar/block/'.$objPage->language.'/'.$cookie['id'].'?redirect=';
+                        $strBlockUrl = 'cookiebar/block/'.$objPage->language.'/'.$cookie['id'].'?redirect=';
 
                         // Check if the element is delivered with a preview image
                         if(strpos($buffer, 'id="splashImage') !== false)


### PR DESCRIPTION
I have a Contao installation in the `/info/` subfolder, which works well except the iframe blocking by Cookiebar. To fix that, I replaced the absolute URL with a relative one. Otherwise the block URL would refer to a non-existing page outside of Contao.

```
https://domain.tld/ – different CMS
https://domain.tld/info/ – Contao
```

The block URL

```
Previously:
https://domain.tld/cookiebar/block/…

Fixed:
https://domain.tld/info/cookiebar/block/…
```