### PR TITLE
Do not init framework in constructor

### DIFF
--- a/src/Command/AnonymizeIpCommand.php
+++ b/src/Command/AnonymizeIpCommand.php
@@ -35,7 +35,6 @@ class AnonymizeIpCommand extends Command
     public function __construct(ContaoFramework $contaoFramework)
     {
         $this->framework = $contaoFramework;
-        $this->framework->initialize();
 
         parent::__construct();
     }
@@ -48,6 +47,7 @@ class AnonymizeIpCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+        $this->framework->initialize();
         $objLog = CookieLogModel::findAll();
 
         if(null !== $objLog)


### PR DESCRIPTION
Same as here: https://github.com/oveleon/contao-component-style-manager/pull/81

The Contao Framework must not be initialised in the constructor of a service.