### PR TITLE
Add word break to force a line break for long cookie enumerations in cookiebar_simple.scss

### DIFF
--- a/src/Resources/public/styles/cookiebar_simple.scss
+++ b/src/Resources/public/styles/cookiebar_simple.scss
@@ -69,6 +69,7 @@ $cookiebar-animation-duration: .5s;
 
         > div + div{
           margin-top: 5px;
+          word-wrap: break-word;
         }
 
         + button.cc-detail-btn-details{


### PR DESCRIPTION
Long Cookie enumerations do a nasty text overflow:
![image](https://user-images.githubusercontent.com/8830861/226887585-e45854c0-9c1e-44fd-91ae-46c8b3bdac0a.png)
