### PR TITLE
Remove m12 class for certain fields

### DIFF
--- a/src/Resources/contao/dca/tl_cookie.php
+++ b/src/Resources/contao/dca/tl_cookie.php
@@ -455,7 +455,7 @@ $GLOBALS['TL_DCA']['tl_cookie'] = array
             'exclude'                 => true,
             'filter'                  => true,
             'inputType'               => 'checkbox',
-            'eval'                    => array('tl_class'=>'w50 m12'),
+            'eval'                    => array('tl_class'=>'w50'),
             'sql'                     => "char(1) NOT NULL default ''",
             'load_callback'           => array(
                 array('tl_cookie', 'disableLockedField')
@@ -467,7 +467,7 @@ $GLOBALS['TL_DCA']['tl_cookie'] = array
             'exclude'                 => true,
             'filter'                  => true,
             'inputType'               => 'checkbox',
-            'eval'                    => array('tl_class'=>'w50 m12'),
+            'eval'                    => array('tl_class'=>'w50'),
             'sql'                     => "char(1) NOT NULL default ''"
         ),
         'blockCookies' => array
@@ -484,7 +484,7 @@ $GLOBALS['TL_DCA']['tl_cookie'] = array
             'exclude'                 => true,
             'filter'                  => true,
             'inputType'               => 'checkbox',
-            'eval'                    => array('doNotCopy'=>true, 'tl_class'=>'w50 m12'),
+            'eval'                    => array('doNotCopy'=>true, 'tl_class'=>'w50'),
             'sql'                     => "char(1) NOT NULL default ''"
         )
 	)


### PR DESCRIPTION
Using the `m12` class is only necessary if the checkbox is displayed to the left or right of a regular `text` or `select` input field for example (so that the checkbox is visually vertically centered with the other input field). These 3 fields are not displayed next to such fields and thus the `m12` class only creates unnecessary whitespace around them.