### PR TITLE
Unlock newer versions of `symfony/serializer`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "ext-libxml": "*",
     "contao/core-bundle":"^4.9.28",
     "symfony/http-foundation":"^4.4 || ^5.2",
-    "symfony/serializer":"^4.4 || ^5.2"
+    "symfony/serializer":"^4.4 || ^5.2 || ^6.4 || ^7.0"
   },
   "require-dev": {
     "contao/manager-plugin": "^2.0"


### PR DESCRIPTION
In one project I need `symfony/serializer: >=6.4` - however, `oveleon/contao-cookiebar` blocks that currently. `symfony/serializer` is an independent component and thus can be unlocked for higher versions. As far as I have checked, nothing has changed in the API of the Serializer component that the `LogExport` uses.