### PR TITLE
bugfix globals $objPage in parseTemplateHook

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,3 +23,4 @@ services:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
             - { name: contao.hook, hook: getFrontendModule, method: onParseLegacyTemplates, priority: 0 }
             - { name: contao.hook, hook: getContentElement, method: onParseLegacyTemplates, priority: 0 }
+            - { name: contao.hook, hook: generatePage, method: onGeneratePage, priority: 0 }

--- a/src/EventListener/KernelRequestListener.php
+++ b/src/EventListener/KernelRequestListener.php
@@ -67,6 +67,10 @@ class KernelRequestListener
                 $this->objRootPage = $rootPageObject;
                 $this->objPage = $pageModel;
 
+                // @TODO instead of use the generatePage-Hook we also can set the $objPage to get the Hooks working when parsing the template
+                // global $objPage;
+                // $objPage = $pageModel;
+
                 $this->prepareCookieBar();
             }
         }
@@ -91,7 +95,8 @@ class KernelRequestListener
         $this->cookies = Cookiebar::validateCookies($this->cookiebarModel);
 
         $this->scriptUtils = new ScriptUtils();
-        $this->scriptUtils->setOutputTemplate(Cookiebar::parseCookiebarTemplate($this->cookiebarModel, $this->objRootPage->language));
+        // @TODO reactivate if globals in Contao are no longer allowed e.g. $objPage
+        // $this->scriptUtils->setOutputTemplate(Cookiebar::parseCookiebarTemplate($this->cookiebarModel, $this->objRootPage->language));
 
         // Always add cache busting
         $javascript = 'bundles/contaocookiebar/scripts/cookiebar.min.js';
@@ -447,5 +452,24 @@ class KernelRequestListener
         }
 
         return $this->parseTemplates($model, $buffer);
+    }
+
+    /**
+     * Use the generatePage Hook the parse the cookieBarTemplate
+     * At this point the Contao globals e.g. global $objPage and the GLOBALS are set
+     * @TODO remove it in future when globals are no longer allowed
+     * @return void
+     */
+    public function onGeneratePage(): void
+    {
+        if (
+            !$this->scriptUtils instanceof ScriptUtils ||
+            !$this->cookiebarModel instanceof CookiebarModel ||
+            !$this->objRootPage instanceof PageModel
+        ) {
+            return;
+        }
+
+        $this->scriptUtils->setOutputTemplate(Cookiebar::parseCookiebarTemplate($this->cookiebarModel, $this->objRootPage->language));
     }
 }

--- a/src/EventListener/KernelRequestListener.php
+++ b/src/EventListener/KernelRequestListener.php
@@ -67,10 +67,6 @@ class KernelRequestListener
                 $this->objRootPage = $rootPageObject;
                 $this->objPage = $pageModel;
 
-                // @TODO instead of use the generatePage-Hook we also can set the $objPage to get the Hooks working when parsing the template
-                // global $objPage;
-                // $objPage = $pageModel;
-
                 $this->prepareCookieBar();
             }
         }
@@ -95,8 +91,6 @@ class KernelRequestListener
         $this->cookies = Cookiebar::validateCookies($this->cookiebarModel);
 
         $this->scriptUtils = new ScriptUtils();
-        // @TODO reactivate if globals in Contao are no longer allowed e.g. $objPage
-        // $this->scriptUtils->setOutputTemplate(Cookiebar::parseCookiebarTemplate($this->cookiebarModel, $this->objRootPage->language));
 
         // Always add cache busting
         $javascript = 'bundles/contaocookiebar/scripts/cookiebar.min.js';
@@ -457,7 +451,6 @@ class KernelRequestListener
     /**
      * Use the generatePage Hook the parse the cookieBarTemplate
      * At this point the Contao globals e.g. global $objPage and the GLOBALS are set
-     * @TODO remove it in future when globals are no longer allowed
      * @return void
      */
     public function onGeneratePage(): void


### PR DESCRIPTION
see https://github.com/oveleon/contao-cookiebar/issues/195#issuecomment-1997458246

@zoglo @fritzmg @doishub 

We have the problem that at the time of parsing the CookiebarTemplate "global $objPage" (and maybe some other Globals set by FrontendIndex) is not set and therefore HookListener for parseTemplate may have a problem.

There are three (four) solutions:

1. set the global $objPage
2. Use the parseLayout-Listener to parse the template
3. let it as it is and do not support global :-) 
(4. temporally deactivate HookListeners when parsing Cookiebar-Template )

My preferred solution is of course 3 :-) , but since Contao still supports it, I would set the global $objPage.
Maybe some other $GLOBALS set by FrontendIndex are still not avalible, but this is only for the parssing of the cookiebar-Template ...

The PR-Draft includes both solutions for 1) and 3). One has to be removed ...

What do you think?


