### PR TITLE
Word-spacing on `body` breaks the cookiebar position

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 const gulp = require('gulp');
 const uglify = require('gulp-uglify');
 const rename = require('gulp-rename');
-const sass = require('gulp-sass');
+const sass = require('gulp-sass')(require('sass'));
 const sourcemaps = require('gulp-sourcemaps');
 
 gulp.task('js', function() {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
     "gulp": "^4.0.2",
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^5.1.0",
+    "gulp-sourcemaps": "^3.0.0",
     "gulp-uglify": "^3.0.2",
-    "gulp-sourcemaps": "^3.0.0"
+    "sass": "^1.75.0"
   },
   "scripts": {
     "buildjs": "gulp js",

--- a/src/Resources/public/styles/_cookiebar.scss
+++ b/src/Resources/public/styles/_cookiebar.scss
@@ -6,6 +6,8 @@
   bottom: 0;
   z-index: 9999;
 
+  display: flex;
+
   font-size: 0; // Required for vertical alignment (responsive)
   letter-spacing: 0;
   text-align: center;
@@ -18,13 +20,6 @@
 
   *{
     box-sizing: border-box;
-  }
-
-  &:before{
-    content: '';
-    display: inline-block;
-    height: 100%;
-    vertical-align: middle;
   }
 
   .cc-inner{
@@ -43,10 +38,7 @@
   }
 
   &.cc-top{
-
-    .cc-inner{
-      vertical-align: top;
-    }
+	align-items: flex-start;
 
     &.cc-active .cc-inner{
       animation: cookiebar-top-in $cookiebar-animation-duration ease-in-out forwards;
@@ -58,10 +50,7 @@
   }
 
   &.cc-bottom{
-
-    .cc-inner {
-      vertical-align: bottom;
-    }
+	align-items: flex-end;
 
     &.cc-active .cc-inner{
       animation: cookiebar-bottom-in $cookiebar-animation-duration ease-in-out forwards;
@@ -73,10 +62,7 @@
   }
 
   &.cc-middle{
-
-    .cc-inner {
-      vertical-align: middle;
-    }
+	align-items: center;
 
     &.cc-active .cc-inner{
       animation: cookiebar-middle-in $cookiebar-animation-duration ease-in-out forwards;
@@ -88,11 +74,15 @@
   }
 
   &.cc-left{
-    text-align: left;
+	justify-content: flex-start;
+  }
+
+  &.cc-middle{
+	justify-content: center;
   }
 
   &.cc-right{
-    text-align: right;
+	justify-content: flex-end;
   }
 
   .cc-head{

--- a/src/Resources/public/styles/_cookiebar.scss
+++ b/src/Resources/public/styles/_cookiebar.scss
@@ -63,6 +63,7 @@
 
   &.cc-middle{
 	align-items: center;
+	justify-content: center;
 
     &.cc-active .cc-inner{
       animation: cookiebar-middle-in $cookiebar-animation-duration ease-in-out forwards;
@@ -75,10 +76,6 @@
 
   &.cc-left{
 	justify-content: flex-start;
-  }
-
-  &.cc-middle{
-	justify-content: center;
   }
 
   &.cc-right{

--- a/src/Resources/public/styles/cookiebar_default.css
+++ b/src/Resources/public/styles/cookiebar_default.css
@@ -6,6 +6,7 @@
   top: 0;
   bottom: 0;
   z-index: 9999;
+  display: flex;
   font-size: 0;
   letter-spacing: 0;
   text-align: center;
@@ -13,336 +14,426 @@
   max-height: 100vh;
   box-sizing: border-box;
   pointer-events: none;
-  overflow: hidden; }
-  .contao-cookiebar * {
-    box-sizing: border-box; }
-  .contao-cookiebar:before {
-    content: '';
-    display: inline-block;
-    height: 100%;
-    vertical-align: middle; }
-  .contao-cookiebar .cc-inner {
-    display: inline-block;
-    overflow-y: auto;
-    max-height: 100%;
-    max-width: 100%;
-    opacity: 0;
-    pointer-events: none;
-    visibility: hidden;
-    font-size: 1rem;
-    text-align: left; }
-  .contao-cookiebar.cc-top .cc-inner {
-    vertical-align: top; }
-  .contao-cookiebar.cc-top.cc-active .cc-inner {
-    animation: cookiebar-top-in 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-top.cc-saved .cc-inner {
-    animation: cookiebar-top-out 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-bottom .cc-inner {
-    vertical-align: bottom; }
-  .contao-cookiebar.cc-bottom.cc-active .cc-inner {
-    animation: cookiebar-bottom-in 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-bottom.cc-saved .cc-inner {
-    animation: cookiebar-bottom-out 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-middle .cc-inner {
-    vertical-align: middle; }
-  .contao-cookiebar.cc-middle.cc-active .cc-inner {
-    animation: cookiebar-middle-in 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-middle.cc-saved .cc-inner {
-    animation: cookiebar-middle-out 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-left {
-    text-align: left; }
-  .contao-cookiebar.cc-right {
-    text-align: right; }
-  .contao-cookiebar .cc-head h1:first-child, .contao-cookiebar .cc-head h2:first-child, .contao-cookiebar .cc-head h3:first-child, .contao-cookiebar .cc-head h4:first-child, .contao-cookiebar .cc-head h5:first-child, .contao-cookiebar .cc-head h6:first-child {
-    margin-top: 0; }
-  .contao-cookiebar .cc-head p {
-    margin-bottom: 15px; }
-  .contao-cookiebar .cc-btn {
-    display: inline-block;
-    cursor: pointer;
-    width: 100%;
-    padding: 8px 14px;
-    margin-bottom: 8px;
-    font-size: 15px;
-    outline: 0 none;
-    border: 1px solid #cfcfcf;
-    border-radius: 4px;
-    color: #444;
-    background: #f5f5f5; }
-    .contao-cookiebar .cc-btn:hover {
-      background: #ececec; }
-    .contao-cookiebar .cc-btn:last-child {
-      margin-bottom: 0; }
-  .contao-cookiebar .grayscale .cc-btn {
-    background: #f1efef; }
-    .contao-cookiebar .grayscale .cc-btn:hover {
-      background: #ececec; }
-    .contao-cookiebar .grayscale .cc-btn.success {
-      background: #fbfbfb; }
-      .contao-cookiebar .grayscale .cc-btn.success:hover {
-        background: #f7f7f7; }
-  .contao-cookiebar .highlight .cc-btn.success {
-    background: #4e9e3e;
-    border-color: #3e7830;
-    color: #fff; }
-    .contao-cookiebar .highlight .cc-btn.success:hover {
-      background: #4c933f; }
-  .contao-cookiebar label {
-    position: relative;
-    display: block;
-    padding: 8px 13px 8px 0;
-    line-height: 1.2rem; }
-    .contao-cookiebar label.group {
-      font-weight: 600; }
-  .contao-cookiebar input {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    outline: 0 none;
-    opacity: 0; }
-    .contao-cookiebar input + label {
-      padding: 8px 13px 8px 50px;
-      cursor: pointer; }
-      .contao-cookiebar input + label:before {
-        content: '';
-        position: absolute;
-        top: 6px;
-        left: 0;
-        width: 35px;
-        height: 18px;
-        margin: 0;
-        box-sizing: content-box;
-        border-radius: 10px;
-        background: #fff;
-        border: 2px solid #9c9b99;
-        transition: border-color .2s; }
-      .contao-cookiebar input + label:after {
-        display: block;
-        content: '';
-        position: absolute;
-        top: 10px;
-        left: 4px;
-        width: 14px;
-        height: 14px;
-        border-radius: 10px;
-        background: #9c9b99;
-        transition: background .2s, margin-left .2s, padding .2s; }
-      .contao-cookiebar input + label:active:after {
-        padding-left: 5px; }
-    .contao-cookiebar input.cc-group-half + label:after {
-      background: linear-gradient(to right, #9c9b99 0%, #9c9b99 50%, #399d32 50%, #399d32 100%); }
-    .contao-cookiebar input:checked + label:after {
-      background: #399d32;
-      margin-left: 17px; }
-    .contao-cookiebar input:checked + label:active:after {
-      margin-left: 12px; }
-    .contao-cookiebar input:checked + label:before {
-      background: #dcf3db;
-      border-color: #399d32; }
-    .contao-cookiebar input:disabled + label {
-      pointer-events: none; }
-      .contao-cookiebar input:disabled + label:after {
-        background: #c8c7c5; }
-      .contao-cookiebar input:disabled + label:before {
-        background: #f4f4f4;
-        border-color: #c8c7c5; }
-  .contao-cookiebar.cc-active .cc-inner {
-    opacity: 1;
-    pointer-events: auto;
-    visibility: visible; }
-  .contao-cookiebar.cc-active.cc-blocked {
-    pointer-events: auto;
-    animation: cookiebar-overlay-in 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-saved.cc-inner {
-    opacity: 0;
-    pointer-events: none;
-    visibility: hidden; }
-  .contao-cookiebar.cc-saved.cc-blocked {
-    pointer-events: none;
-    animation: cookiebar-overlay-out 0.5s ease-in-out forwards; }
+  overflow: hidden;
+}
+.contao-cookiebar * {
+  box-sizing: border-box;
+}
+.contao-cookiebar .cc-inner {
+  display: inline-block;
+  overflow-y: auto;
+  max-height: 100%;
+  max-width: 100%;
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+  font-size: 1rem;
+  text-align: left;
+}
+.contao-cookiebar.cc-top {
+  align-items: flex-start;
+}
+.contao-cookiebar.cc-top.cc-active .cc-inner {
+  animation: cookiebar-top-in 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-top.cc-saved .cc-inner {
+  animation: cookiebar-top-out 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-bottom {
+  align-items: flex-end;
+}
+.contao-cookiebar.cc-bottom.cc-active .cc-inner {
+  animation: cookiebar-bottom-in 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-bottom.cc-saved .cc-inner {
+  animation: cookiebar-bottom-out 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-middle {
+  align-items: center;
+}
+.contao-cookiebar.cc-middle.cc-active .cc-inner {
+  animation: cookiebar-middle-in 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-middle.cc-saved .cc-inner {
+  animation: cookiebar-middle-out 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-left {
+  justify-content: flex-start;
+}
+.contao-cookiebar.cc-middle {
+  justify-content: center;
+}
+.contao-cookiebar.cc-right {
+  justify-content: flex-end;
+}
+.contao-cookiebar .cc-head h1:first-child, .contao-cookiebar .cc-head h2:first-child, .contao-cookiebar .cc-head h3:first-child, .contao-cookiebar .cc-head h4:first-child, .contao-cookiebar .cc-head h5:first-child, .contao-cookiebar .cc-head h6:first-child {
+  margin-top: 0;
+}
+.contao-cookiebar .cc-head p {
+  margin-bottom: 15px;
+}
+.contao-cookiebar .cc-btn {
+  display: inline-block;
+  cursor: pointer;
+  width: 100%;
+  padding: 8px 14px;
+  margin-bottom: 8px;
+  font-size: 15px;
+  outline: 0 none;
+  border: 1px solid #cfcfcf;
+  border-radius: 4px;
+  color: #444;
+  background: #f5f5f5;
+}
+.contao-cookiebar .cc-btn:hover {
+  background: #ececec;
+}
+.contao-cookiebar .cc-btn:last-child {
+  margin-bottom: 0;
+}
+.contao-cookiebar .grayscale .cc-btn {
+  background: #f1efef;
+}
+.contao-cookiebar .grayscale .cc-btn:hover {
+  background: #ececec;
+}
+.contao-cookiebar .grayscale .cc-btn.success {
+  background: #fbfbfb;
+}
+.contao-cookiebar .grayscale .cc-btn.success:hover {
+  background: #f7f7f7;
+}
+.contao-cookiebar .highlight .cc-btn.success {
+  background: #4e9e3e;
+  border-color: #3e7830;
+  color: #fff;
+}
+.contao-cookiebar .highlight .cc-btn.success:hover {
+  background: #4c933f;
+}
+.contao-cookiebar label {
+  position: relative;
+  display: block;
+  padding: 8px 13px 8px 0;
+  line-height: 1.2rem;
+}
+.contao-cookiebar label.group {
+  font-weight: 600;
+}
+.contao-cookiebar input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  outline: 0 none;
+  opacity: 0;
+}
+.contao-cookiebar input + label {
+  padding: 8px 13px 8px 50px;
+  cursor: pointer;
+}
+.contao-cookiebar input + label:before {
+  content: "";
+  position: absolute;
+  top: 6px;
+  left: 0;
+  width: 35px;
+  height: 18px;
+  margin: 0;
+  box-sizing: content-box;
+  border-radius: 10px;
+  background: #fff;
+  border: 2px solid #9c9b99;
+  transition: border-color 0.2s;
+}
+.contao-cookiebar input + label:after {
+  display: block;
+  content: "";
+  position: absolute;
+  top: 10px;
+  left: 4px;
+  width: 14px;
+  height: 14px;
+  border-radius: 10px;
+  background: #9c9b99;
+  transition: background 0.2s, margin-left 0.2s, padding 0.2s;
+}
+.contao-cookiebar input + label:active:after {
+  padding-left: 5px;
+}
+.contao-cookiebar input.cc-group-half + label:after {
+  background: linear-gradient(to right, #9c9b99 0%, #9c9b99 50%, #399d32 50%, #399d32 100%);
+}
+.contao-cookiebar input:checked + label:after {
+  background: #399d32;
+  margin-left: 17px;
+}
+.contao-cookiebar input:checked + label:active:after {
+  margin-left: 12px;
+}
+.contao-cookiebar input:checked + label:before {
+  background: #dcf3db;
+  border-color: #399d32;
+}
+.contao-cookiebar input:disabled + label {
+  pointer-events: none;
+}
+.contao-cookiebar input:disabled + label:after {
+  background: #c8c7c5;
+}
+.contao-cookiebar input:disabled + label:before {
+  background: #f4f4f4;
+  border-color: #c8c7c5;
+}
+.contao-cookiebar.cc-active .cc-inner {
+  opacity: 1;
+  pointer-events: auto;
+  visibility: visible;
+}
+.contao-cookiebar.cc-active.cc-blocked {
+  pointer-events: auto;
+  animation: cookiebar-overlay-in 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-saved.cc-inner {
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+.contao-cookiebar.cc-saved.cc-blocked {
+  pointer-events: none;
+  animation: cookiebar-overlay-out 0.5s ease-in-out forwards;
+}
 
 @media (min-width: 768px) {
   .contao-cookiebar .cc-btn {
     width: auto;
-    margin-bottom: 0; }
+    margin-bottom: 0;
+  }
   .contao-cookiebar .cc-inner {
-    max-width: 750px; } }
-
+    max-width: 750px;
+  }
+}
 @keyframes cookiebar-overlay-in {
   0% {
-    background: rgba(0, 0, 0, 0); }
+    background: rgba(0, 0, 0, 0);
+  }
   100% {
-    background: rgba(0, 0, 0, 0.75); } }
-
+    background: rgba(0, 0, 0, 0.75);
+  }
+}
 @keyframes cookiebar-overlay-out {
   0% {
-    background: rgba(0, 0, 0, 0.75); }
+    background: rgba(0, 0, 0, 0.75);
+  }
   100% {
     background: rgba(0, 0, 0, 0);
-    visibility: hidden; } }
-
+    visibility: hidden;
+  }
+}
 @keyframes cookiebar-top-in {
   0% {
     opacity: 0;
-    transform: translateY(-100%); }
+    transform: translateY(-100%);
+  }
   100% {
     opacity: 1;
-    transform: translateY(0); } }
-
+    transform: translateY(0);
+  }
+}
 @keyframes cookiebar-top-out {
   0% {
     opacity: 1;
     visibility: visible;
-    transform: translateY(0); }
+    transform: translateY(0);
+  }
   100% {
     opacity: 0;
     visibility: hidden;
-    transform: translateY(-100%); } }
-
+    transform: translateY(-100%);
+  }
+}
 @keyframes cookiebar-middle-in {
   0% {
     opacity: 0;
-    transform: scale(0); }
+    transform: scale(0);
+  }
   100% {
     opacity: 1;
-    transform: scale(1); } }
-
+    transform: scale(1);
+  }
+}
 @keyframes cookiebar-middle-out {
   0% {
     opacity: 1;
     visibility: visible;
-    transform: scale(1); }
+    transform: scale(1);
+  }
   100% {
     opacity: 0;
     visibility: hidden;
-    transform: scale(0); } }
-
+    transform: scale(0);
+  }
+}
 @keyframes cookiebar-bottom-in {
   0% {
     opacity: 0;
-    transform: translateY(100%); }
+    transform: translateY(100%);
+  }
   100% {
     opacity: 1;
-    transform: translateY(0); } }
-
+    transform: translateY(0);
+  }
+}
 @keyframes cookiebar-bottom-out {
   0% {
     opacity: 1;
     visibility: visible;
-    transform: translateY(0); }
+    transform: translateY(0);
+  }
   100% {
     opacity: 0;
     visibility: hidden;
-    transform: translateY(100%); } }
-
+    transform: translateY(100%);
+  }
+}
 .contao-cookiebar {
-  color: #444444; }
-  .contao-cookiebar p {
-    color: #868686;
-    line-height: 1.4; }
-  .contao-cookiebar .cc-inner {
-    padding: 25px;
-    border-radius: 5px;
-    -webkit-box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25);
-    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25);
-    background: #fff; }
-  .contao-cookiebar .cc-group {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-content: center;
-    position: relative;
-    border: 1px solid #d0d0d0;
-    border-radius: 5px;
-    margin-bottom: 10px; }
-    .contao-cookiebar .cc-group > label {
-      flex-grow: 1;
-      margin: 5px 0 5px 10px; }
-    .contao-cookiebar .cc-group .cc-detail-btn {
-      border: 0 none;
-      outline: 0 none;
-      background: transparent;
-      font-size: 13px;
-      letter-spacing: 0;
-      text-transform: initial;
-      cursor: pointer;
-      color: #a2a2a2;
-      padding: 8px 10px;
-      line-height: 1.2rem; }
-      .contao-cookiebar .cc-group .cc-detail-btn span:nth-child(2) {
-        display: none; }
-      .contao-cookiebar .cc-group .cc-detail-btn.cc-active span:nth-child(1) {
-        display: none; }
-      .contao-cookiebar .cc-group .cc-detail-btn.cc-active span:nth-child(2) {
-        display: inline; }
-      .contao-cookiebar .cc-group .cc-detail-btn:hover {
-        color: #717171; }
-    .contao-cookiebar .cc-group .cc-detail-btn-details {
-      display: inline-block;
-      border: 0 none;
-      outline: 0 none;
-      background: transparent;
-      font-size: 13px;
-      letter-spacing: 0;
-      text-transform: initial;
-      cursor: pointer;
-      color: #a2a2a2;
-      text-decoration: underline;
-      padding: 0;
-      margin: 0 0 10px; }
-      .contao-cookiebar .cc-group .cc-detail-btn-details span:nth-child(2) {
-        display: none; }
-      .contao-cookiebar .cc-group .cc-detail-btn-details.cc-active span:nth-child(1) {
-        display: none; }
-      .contao-cookiebar .cc-group .cc-detail-btn-details.cc-active span:nth-child(2) {
-        display: inline; }
-      .contao-cookiebar .cc-group .cc-detail-btn-details:hover {
-        color: #717171; }
-  .contao-cookiebar .cc-cookies {
-    display: none;
-    width: 100%;
-    background: #fbfbfb;
-    border-radius: 0 0 5px 5px; }
-    .contao-cookiebar .cc-cookies > p {
-      font-size: 0.875rem; }
-    .contao-cookiebar .cc-cookies > p, .contao-cookiebar .cc-cookies > .cc-cookie {
-      margin: 0;
-      padding: 15px;
-      border-top: 1px solid #e6e6e6; }
-    .contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info {
-      font-size: 0.875rem;
-      background: #fff;
-      padding: 10px;
-      border-radius: 5px;
-      border: 1px solid #efefef; }
-      .contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info > div > span {
-        font-weight: 600; }
-      .contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info > div + div {
-        margin-top: 5px;
-        word-wrap: break-word; }
-      .contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info + button.cc-detail-btn-details {
-        margin-top: 15px; }
-    .contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-desc > p {
-      margin-bottom: 0; }
-    .contao-cookiebar .cc-cookies .cc-cookie label.cookie + p, .contao-cookiebar .cc-cookies .cc-cookie label.cookie + .cc-cookie-info, .contao-cookiebar .cc-cookies .cc-cookie label.cookie + button.cc-detail-btn-details {
-      margin-top: 10px; }
-    .contao-cookiebar .cc-cookies .cc-cookie p {
-      margin: 0 0 15px;
-      font-size: 0.875rem; }
-  .contao-cookiebar .cc-footer, .contao-cookiebar .cc-info {
-    text-align: center; }
-  .contao-cookiebar .cc-info {
-    margin-top: 15px; }
-    .contao-cookiebar .cc-info > p {
-      font-size: 0.875rem; }
-    .contao-cookiebar .cc-info > a {
-      display: inline-block;
-      font-size: 0.813rem;
-      color: #a2a2a2;
-      text-decoration: none; }
-      .contao-cookiebar .cc-info > a:hover {
-        color: #717171; }
-      .contao-cookiebar .cc-info > a + a:before {
-        display: inline-block;
-        content: '·';
-        margin-right: 5px; }
+  color: #444444;
+}
+.contao-cookiebar p {
+  color: #868686;
+  line-height: 1.4;
+}
+.contao-cookiebar .cc-inner {
+  padding: 25px;
+  border-radius: 5px;
+  -webkit-box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25);
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25);
+  background: #fff;
+}
+.contao-cookiebar .cc-group {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-content: center;
+  position: relative;
+  border: 1px solid #d0d0d0;
+  border-radius: 5px;
+  margin-bottom: 10px;
+}
+.contao-cookiebar .cc-group > label {
+  flex-grow: 1;
+  margin: 5px 0 5px 10px;
+}
+.contao-cookiebar .cc-group .cc-detail-btn {
+  border: 0 none;
+  outline: 0 none;
+  background: transparent;
+  font-size: 13px;
+  letter-spacing: 0;
+  text-transform: initial;
+  cursor: pointer;
+  color: #a2a2a2;
+  padding: 8px 10px;
+  line-height: 1.2rem;
+}
+.contao-cookiebar .cc-group .cc-detail-btn span:nth-child(2) {
+  display: none;
+}
+.contao-cookiebar .cc-group .cc-detail-btn.cc-active span:nth-child(1) {
+  display: none;
+}
+.contao-cookiebar .cc-group .cc-detail-btn.cc-active span:nth-child(2) {
+  display: inline;
+}
+.contao-cookiebar .cc-group .cc-detail-btn:hover {
+  color: #717171;
+}
+.contao-cookiebar .cc-group .cc-detail-btn-details {
+  display: inline-block;
+  border: 0 none;
+  outline: 0 none;
+  background: transparent;
+  font-size: 13px;
+  letter-spacing: 0;
+  text-transform: initial;
+  cursor: pointer;
+  color: #a2a2a2;
+  text-decoration: underline;
+  padding: 0;
+  margin: 0 0 10px;
+}
+.contao-cookiebar .cc-group .cc-detail-btn-details span:nth-child(2) {
+  display: none;
+}
+.contao-cookiebar .cc-group .cc-detail-btn-details.cc-active span:nth-child(1) {
+  display: none;
+}
+.contao-cookiebar .cc-group .cc-detail-btn-details.cc-active span:nth-child(2) {
+  display: inline;
+}
+.contao-cookiebar .cc-group .cc-detail-btn-details:hover {
+  color: #717171;
+}
+.contao-cookiebar .cc-cookies {
+  display: none;
+  width: 100%;
+  background: #fbfbfb;
+  border-radius: 0 0 5px 5px;
+}
+.contao-cookiebar .cc-cookies > p {
+  font-size: 0.875rem;
+}
+.contao-cookiebar .cc-cookies > p, .contao-cookiebar .cc-cookies > .cc-cookie {
+  margin: 0;
+  padding: 15px;
+  border-top: 1px solid #e6e6e6;
+}
+.contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info {
+  font-size: 0.875rem;
+  background: #fff;
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid #efefef;
+}
+.contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info > div > span {
+  font-weight: 600;
+}
+.contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info > div + div {
+  margin-top: 5px;
+  word-wrap: break-word;
+}
+.contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info + button.cc-detail-btn-details {
+  margin-top: 15px;
+}
+.contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-desc > p {
+  margin-bottom: 0;
+}
+.contao-cookiebar .cc-cookies .cc-cookie label.cookie + p, .contao-cookiebar .cc-cookies .cc-cookie label.cookie + .cc-cookie-info, .contao-cookiebar .cc-cookies .cc-cookie label.cookie + button.cc-detail-btn-details {
+  margin-top: 10px;
+}
+.contao-cookiebar .cc-cookies .cc-cookie p {
+  margin: 0 0 15px;
+  font-size: 0.875rem;
+}
+.contao-cookiebar .cc-footer, .contao-cookiebar .cc-info {
+  text-align: center;
+}
+.contao-cookiebar .cc-info {
+  margin-top: 15px;
+}
+.contao-cookiebar .cc-info > p {
+  font-size: 0.875rem;
+}
+.contao-cookiebar .cc-info > a {
+  display: inline-block;
+  font-size: 0.813rem;
+  color: #a2a2a2;
+  text-decoration: none;
+}
+.contao-cookiebar .cc-info > a:hover {
+  color: #717171;
+}
+.contao-cookiebar .cc-info > a + a:before {
+  display: inline-block;
+  content: "·";
+  margin-right: 5px;
+}

--- a/src/Resources/public/styles/cookiebar_simple.css
+++ b/src/Resources/public/styles/cookiebar_simple.css
@@ -6,6 +6,7 @@
   top: 0;
   bottom: 0;
   z-index: 9999;
+  display: flex;
   font-size: 0;
   letter-spacing: 0;
   text-align: center;
@@ -13,313 +14,399 @@
   max-height: 100vh;
   box-sizing: border-box;
   pointer-events: none;
-  overflow: hidden; }
-  .contao-cookiebar * {
-    box-sizing: border-box; }
-  .contao-cookiebar:before {
-    content: '';
-    display: inline-block;
-    height: 100%;
-    vertical-align: middle; }
-  .contao-cookiebar .cc-inner {
-    display: inline-block;
-    overflow-y: auto;
-    max-height: 100%;
-    max-width: 100%;
-    opacity: 0;
-    pointer-events: none;
-    visibility: hidden;
-    font-size: 1rem;
-    text-align: left; }
-  .contao-cookiebar.cc-top .cc-inner {
-    vertical-align: top; }
-  .contao-cookiebar.cc-top.cc-active .cc-inner {
-    animation: cookiebar-top-in 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-top.cc-saved .cc-inner {
-    animation: cookiebar-top-out 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-bottom .cc-inner {
-    vertical-align: bottom; }
-  .contao-cookiebar.cc-bottom.cc-active .cc-inner {
-    animation: cookiebar-bottom-in 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-bottom.cc-saved .cc-inner {
-    animation: cookiebar-bottom-out 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-middle .cc-inner {
-    vertical-align: middle; }
-  .contao-cookiebar.cc-middle.cc-active .cc-inner {
-    animation: cookiebar-middle-in 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-middle.cc-saved .cc-inner {
-    animation: cookiebar-middle-out 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-left {
-    text-align: left; }
-  .contao-cookiebar.cc-right {
-    text-align: right; }
-  .contao-cookiebar .cc-head h1:first-child, .contao-cookiebar .cc-head h2:first-child, .contao-cookiebar .cc-head h3:first-child, .contao-cookiebar .cc-head h4:first-child, .contao-cookiebar .cc-head h5:first-child, .contao-cookiebar .cc-head h6:first-child {
-    margin-top: 0; }
-  .contao-cookiebar .cc-head p {
-    margin-bottom: 15px; }
-  .contao-cookiebar .cc-btn {
-    display: inline-block;
-    cursor: pointer;
-    width: 100%;
-    padding: 8px 14px;
-    margin-bottom: 8px;
-    font-size: 15px;
-    outline: 0 none;
-    border: 1px solid #cfcfcf;
-    border-radius: 4px;
-    color: #444;
-    background: #f5f5f5; }
-    .contao-cookiebar .cc-btn:hover {
-      background: #ececec; }
-    .contao-cookiebar .cc-btn:last-child {
-      margin-bottom: 0; }
-  .contao-cookiebar .grayscale .cc-btn {
-    background: #f1efef; }
-    .contao-cookiebar .grayscale .cc-btn:hover {
-      background: #ececec; }
-    .contao-cookiebar .grayscale .cc-btn.success {
-      background: #fbfbfb; }
-      .contao-cookiebar .grayscale .cc-btn.success:hover {
-        background: #f7f7f7; }
-  .contao-cookiebar .highlight .cc-btn.success {
-    background: #4e9e3e;
-    border-color: #3e7830;
-    color: #fff; }
-    .contao-cookiebar .highlight .cc-btn.success:hover {
-      background: #4c933f; }
-  .contao-cookiebar label {
-    position: relative;
-    display: block;
-    padding: 8px 13px 8px 0;
-    line-height: 1.2rem; }
-    .contao-cookiebar label.group {
-      font-weight: 600; }
-  .contao-cookiebar input {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    outline: 0 none;
-    opacity: 0; }
-    .contao-cookiebar input + label {
-      padding: 8px 13px 8px 50px;
-      cursor: pointer; }
-      .contao-cookiebar input + label:before {
-        content: '';
-        position: absolute;
-        top: 6px;
-        left: 0;
-        width: 35px;
-        height: 18px;
-        margin: 0;
-        box-sizing: content-box;
-        border-radius: 10px;
-        background: #fff;
-        border: 2px solid #9c9b99;
-        transition: border-color .2s; }
-      .contao-cookiebar input + label:after {
-        display: block;
-        content: '';
-        position: absolute;
-        top: 10px;
-        left: 4px;
-        width: 14px;
-        height: 14px;
-        border-radius: 10px;
-        background: #9c9b99;
-        transition: background .2s, margin-left .2s, padding .2s; }
-      .contao-cookiebar input + label:active:after {
-        padding-left: 5px; }
-    .contao-cookiebar input.cc-group-half + label:after {
-      background: linear-gradient(to right, #9c9b99 0%, #9c9b99 50%, #399d32 50%, #399d32 100%); }
-    .contao-cookiebar input:checked + label:after {
-      background: #399d32;
-      margin-left: 17px; }
-    .contao-cookiebar input:checked + label:active:after {
-      margin-left: 12px; }
-    .contao-cookiebar input:checked + label:before {
-      background: #dcf3db;
-      border-color: #399d32; }
-    .contao-cookiebar input:disabled + label {
-      pointer-events: none; }
-      .contao-cookiebar input:disabled + label:after {
-        background: #c8c7c5; }
-      .contao-cookiebar input:disabled + label:before {
-        background: #f4f4f4;
-        border-color: #c8c7c5; }
-  .contao-cookiebar.cc-active .cc-inner {
-    opacity: 1;
-    pointer-events: auto;
-    visibility: visible; }
-  .contao-cookiebar.cc-active.cc-blocked {
-    pointer-events: auto;
-    animation: cookiebar-overlay-in 0.5s ease-in-out forwards; }
-  .contao-cookiebar.cc-saved.cc-inner {
-    opacity: 0;
-    pointer-events: none;
-    visibility: hidden; }
-  .contao-cookiebar.cc-saved.cc-blocked {
-    pointer-events: none;
-    animation: cookiebar-overlay-out 0.5s ease-in-out forwards; }
+  overflow: hidden;
+}
+.contao-cookiebar * {
+  box-sizing: border-box;
+}
+.contao-cookiebar .cc-inner {
+  display: inline-block;
+  overflow-y: auto;
+  max-height: 100%;
+  max-width: 100%;
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+  font-size: 1rem;
+  text-align: left;
+}
+.contao-cookiebar.cc-top {
+  align-items: flex-start;
+}
+.contao-cookiebar.cc-top.cc-active .cc-inner {
+  animation: cookiebar-top-in 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-top.cc-saved .cc-inner {
+  animation: cookiebar-top-out 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-bottom {
+  align-items: flex-end;
+}
+.contao-cookiebar.cc-bottom.cc-active .cc-inner {
+  animation: cookiebar-bottom-in 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-bottom.cc-saved .cc-inner {
+  animation: cookiebar-bottom-out 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-middle {
+  align-items: center;
+}
+.contao-cookiebar.cc-middle.cc-active .cc-inner {
+  animation: cookiebar-middle-in 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-middle.cc-saved .cc-inner {
+  animation: cookiebar-middle-out 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-left {
+  justify-content: flex-start;
+}
+.contao-cookiebar.cc-middle {
+  justify-content: center;
+}
+.contao-cookiebar.cc-right {
+  justify-content: flex-end;
+}
+.contao-cookiebar .cc-head h1:first-child, .contao-cookiebar .cc-head h2:first-child, .contao-cookiebar .cc-head h3:first-child, .contao-cookiebar .cc-head h4:first-child, .contao-cookiebar .cc-head h5:first-child, .contao-cookiebar .cc-head h6:first-child {
+  margin-top: 0;
+}
+.contao-cookiebar .cc-head p {
+  margin-bottom: 15px;
+}
+.contao-cookiebar .cc-btn {
+  display: inline-block;
+  cursor: pointer;
+  width: 100%;
+  padding: 8px 14px;
+  margin-bottom: 8px;
+  font-size: 15px;
+  outline: 0 none;
+  border: 1px solid #cfcfcf;
+  border-radius: 4px;
+  color: #444;
+  background: #f5f5f5;
+}
+.contao-cookiebar .cc-btn:hover {
+  background: #ececec;
+}
+.contao-cookiebar .cc-btn:last-child {
+  margin-bottom: 0;
+}
+.contao-cookiebar .grayscale .cc-btn {
+  background: #f1efef;
+}
+.contao-cookiebar .grayscale .cc-btn:hover {
+  background: #ececec;
+}
+.contao-cookiebar .grayscale .cc-btn.success {
+  background: #fbfbfb;
+}
+.contao-cookiebar .grayscale .cc-btn.success:hover {
+  background: #f7f7f7;
+}
+.contao-cookiebar .highlight .cc-btn.success {
+  background: #4e9e3e;
+  border-color: #3e7830;
+  color: #fff;
+}
+.contao-cookiebar .highlight .cc-btn.success:hover {
+  background: #4c933f;
+}
+.contao-cookiebar label {
+  position: relative;
+  display: block;
+  padding: 8px 13px 8px 0;
+  line-height: 1.2rem;
+}
+.contao-cookiebar label.group {
+  font-weight: 600;
+}
+.contao-cookiebar input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  outline: 0 none;
+  opacity: 0;
+}
+.contao-cookiebar input + label {
+  padding: 8px 13px 8px 50px;
+  cursor: pointer;
+}
+.contao-cookiebar input + label:before {
+  content: "";
+  position: absolute;
+  top: 6px;
+  left: 0;
+  width: 35px;
+  height: 18px;
+  margin: 0;
+  box-sizing: content-box;
+  border-radius: 10px;
+  background: #fff;
+  border: 2px solid #9c9b99;
+  transition: border-color 0.2s;
+}
+.contao-cookiebar input + label:after {
+  display: block;
+  content: "";
+  position: absolute;
+  top: 10px;
+  left: 4px;
+  width: 14px;
+  height: 14px;
+  border-radius: 10px;
+  background: #9c9b99;
+  transition: background 0.2s, margin-left 0.2s, padding 0.2s;
+}
+.contao-cookiebar input + label:active:after {
+  padding-left: 5px;
+}
+.contao-cookiebar input.cc-group-half + label:after {
+  background: linear-gradient(to right, #9c9b99 0%, #9c9b99 50%, #399d32 50%, #399d32 100%);
+}
+.contao-cookiebar input:checked + label:after {
+  background: #399d32;
+  margin-left: 17px;
+}
+.contao-cookiebar input:checked + label:active:after {
+  margin-left: 12px;
+}
+.contao-cookiebar input:checked + label:before {
+  background: #dcf3db;
+  border-color: #399d32;
+}
+.contao-cookiebar input:disabled + label {
+  pointer-events: none;
+}
+.contao-cookiebar input:disabled + label:after {
+  background: #c8c7c5;
+}
+.contao-cookiebar input:disabled + label:before {
+  background: #f4f4f4;
+  border-color: #c8c7c5;
+}
+.contao-cookiebar.cc-active .cc-inner {
+  opacity: 1;
+  pointer-events: auto;
+  visibility: visible;
+}
+.contao-cookiebar.cc-active.cc-blocked {
+  pointer-events: auto;
+  animation: cookiebar-overlay-in 0.5s ease-in-out forwards;
+}
+.contao-cookiebar.cc-saved.cc-inner {
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+.contao-cookiebar.cc-saved.cc-blocked {
+  pointer-events: none;
+  animation: cookiebar-overlay-out 0.5s ease-in-out forwards;
+}
 
 @media (min-width: 768px) {
   .contao-cookiebar .cc-btn {
     width: auto;
-    margin-bottom: 0; }
+    margin-bottom: 0;
+  }
   .contao-cookiebar .cc-inner {
-    max-width: 750px; } }
-
+    max-width: 750px;
+  }
+}
 @keyframes cookiebar-overlay-in {
   0% {
-    background: rgba(0, 0, 0, 0); }
+    background: rgba(0, 0, 0, 0);
+  }
   100% {
-    background: rgba(0, 0, 0, 0.75); } }
-
+    background: rgba(0, 0, 0, 0.75);
+  }
+}
 @keyframes cookiebar-overlay-out {
   0% {
-    background: rgba(0, 0, 0, 0.75); }
+    background: rgba(0, 0, 0, 0.75);
+  }
   100% {
     background: rgba(0, 0, 0, 0);
-    visibility: hidden; } }
-
+    visibility: hidden;
+  }
+}
 @keyframes cookiebar-top-in {
   0% {
     opacity: 0;
-    transform: translateY(-100%); }
+    transform: translateY(-100%);
+  }
   100% {
     opacity: 1;
-    transform: translateY(0); } }
-
+    transform: translateY(0);
+  }
+}
 @keyframes cookiebar-top-out {
   0% {
     opacity: 1;
     visibility: visible;
-    transform: translateY(0); }
+    transform: translateY(0);
+  }
   100% {
     opacity: 0;
     visibility: hidden;
-    transform: translateY(-100%); } }
-
+    transform: translateY(-100%);
+  }
+}
 @keyframes cookiebar-middle-in {
   0% {
     opacity: 0;
-    transform: scale(0); }
+    transform: scale(0);
+  }
   100% {
     opacity: 1;
-    transform: scale(1); } }
-
+    transform: scale(1);
+  }
+}
 @keyframes cookiebar-middle-out {
   0% {
     opacity: 1;
     visibility: visible;
-    transform: scale(1); }
+    transform: scale(1);
+  }
   100% {
     opacity: 0;
     visibility: hidden;
-    transform: scale(0); } }
-
+    transform: scale(0);
+  }
+}
 @keyframes cookiebar-bottom-in {
   0% {
     opacity: 0;
-    transform: translateY(100%); }
+    transform: translateY(100%);
+  }
   100% {
     opacity: 1;
-    transform: translateY(0); } }
-
+    transform: translateY(0);
+  }
+}
 @keyframes cookiebar-bottom-out {
   0% {
     opacity: 1;
     visibility: visible;
-    transform: translateY(0); }
+    transform: translateY(0);
+  }
   100% {
     opacity: 0;
     visibility: hidden;
-    transform: translateY(100%); } }
-
+    transform: translateY(100%);
+  }
+}
 .contao-cookiebar {
-  color: #444444; }
-  .contao-cookiebar p {
-    color: #868686;
-    line-height: 1.4; }
-  .contao-cookiebar .cc-inner {
-    padding: 25px;
-    border-radius: 5px;
-    -webkit-box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25);
-    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25);
-    background: #fff; }
-  .contao-cookiebar .cc-groups {
-    display: none;
-    padding-top: 15px; }
-    .contao-cookiebar .cc-groups .cc-group {
-      position: relative;
-      border: 1px solid #d0d0d0;
-      border-radius: 5px;
-      margin-bottom: 10px;
-      text-align: left; }
-      .contao-cookiebar .cc-groups .cc-group > label {
-        margin: 5px 130px 5px 10px; }
-  .contao-cookiebar .cc-cookies {
-    background: #fbfbfb;
-    border-radius: 0 0 5px 5px; }
-    .contao-cookiebar .cc-cookies > p {
-      font-size: 0.875rem; }
-    .contao-cookiebar .cc-cookies > p, .contao-cookiebar .cc-cookies > .cc-cookie {
-      margin: 0;
-      padding: 15px;
-      border-top: 1px solid #e6e6e6; }
-    .contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info {
-      font-size: 0.875rem;
-      background: #fff;
-      padding: 10px;
-      border-radius: 5px;
-      border: 1px solid #efefef; }
-      .contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info > div > span {
-        font-weight: 600; }
-      .contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info > div + div {
-        margin-top: 5px;
-        word-wrap: break-word; }
-      .contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info + button.cc-detail-btn-details {
-        margin-top: 15px; }
-    .contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-desc p {
-      margin-bottom: 0; }
-    .contao-cookiebar .cc-cookies .cc-cookie label.cookie + p, .contao-cookiebar .cc-cookies .cc-cookie label.cookie + .cc-cookie-info, .contao-cookiebar .cc-cookies .cc-cookie label.cookie + button.cc-detail-btn-details {
-      margin-top: 10px; }
-    .contao-cookiebar .cc-cookies .cc-cookie p {
-      margin: 0 0 15px;
-      font-size: 0.875rem; }
-  .contao-cookiebar .cc-footer, .contao-cookiebar .cc-info {
-    text-align: center; }
-  .contao-cookiebar .cc-detail-btn-details {
-    border: 0 none;
-    outline: 0 none;
-    background: transparent;
-    font-size: 13px;
-    letter-spacing: 0;
-    text-transform: initial;
-    cursor: pointer;
-    color: #a2a2a2;
-    text-decoration: underline;
-    padding: 0;
-    margin: 0 0 10px; }
-    .contao-cookiebar .cc-detail-btn-details span:nth-child(2) {
-      display: none; }
-    .contao-cookiebar .cc-detail-btn-details.cc-active span:nth-child(1) {
-      display: none; }
-    .contao-cookiebar .cc-detail-btn-details.cc-active span:nth-child(2) {
-      display: inline; }
-    .contao-cookiebar .cc-detail-btn-details:hover {
-      color: #717171; }
-  .contao-cookiebar .cc-info {
-    margin-top: 15px; }
-    .contao-cookiebar .cc-info > p {
-      font-size: 0.875rem; }
-    .contao-cookiebar .cc-info > a {
-      display: inline-block;
-      font-size: 0.813rem;
-      color: #a2a2a2;
-      text-decoration: none; }
-      .contao-cookiebar .cc-info > a:hover {
-        color: #717171; }
-      .contao-cookiebar .cc-info > a + a:before {
-        display: inline-block;
-        content: '·';
-        margin-right: 5px; }
+  color: #444444;
+}
+.contao-cookiebar p {
+  color: #868686;
+  line-height: 1.4;
+}
+.contao-cookiebar .cc-inner {
+  padding: 25px;
+  border-radius: 5px;
+  -webkit-box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25);
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25);
+  background: #fff;
+}
+.contao-cookiebar .cc-groups {
+  display: none;
+  padding-top: 15px;
+}
+.contao-cookiebar .cc-groups .cc-group {
+  position: relative;
+  border: 1px solid #d0d0d0;
+  border-radius: 5px;
+  margin-bottom: 10px;
+  text-align: left;
+}
+.contao-cookiebar .cc-groups .cc-group > label {
+  margin: 5px 130px 5px 10px;
+}
+.contao-cookiebar .cc-cookies {
+  background: #fbfbfb;
+  border-radius: 0 0 5px 5px;
+}
+.contao-cookiebar .cc-cookies > p {
+  font-size: 0.875rem;
+}
+.contao-cookiebar .cc-cookies > p, .contao-cookiebar .cc-cookies > .cc-cookie {
+  margin: 0;
+  padding: 15px;
+  border-top: 1px solid #e6e6e6;
+}
+.contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info {
+  font-size: 0.875rem;
+  background: #fff;
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid #efefef;
+}
+.contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info > div > span {
+  font-weight: 600;
+}
+.contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info > div + div {
+  margin-top: 5px;
+  word-wrap: break-word;
+}
+.contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-info + button.cc-detail-btn-details {
+  margin-top: 15px;
+}
+.contao-cookiebar .cc-cookies .cc-cookie .cc-cookie-desc p {
+  margin-bottom: 0;
+}
+.contao-cookiebar .cc-cookies .cc-cookie label.cookie + p, .contao-cookiebar .cc-cookies .cc-cookie label.cookie + .cc-cookie-info, .contao-cookiebar .cc-cookies .cc-cookie label.cookie + button.cc-detail-btn-details {
+  margin-top: 10px;
+}
+.contao-cookiebar .cc-cookies .cc-cookie p {
+  margin: 0 0 15px;
+  font-size: 0.875rem;
+}
+.contao-cookiebar .cc-footer, .contao-cookiebar .cc-info {
+  text-align: center;
+}
+.contao-cookiebar .cc-detail-btn-details {
+  border: 0 none;
+  outline: 0 none;
+  background: transparent;
+  font-size: 13px;
+  letter-spacing: 0;
+  text-transform: initial;
+  cursor: pointer;
+  color: #a2a2a2;
+  text-decoration: underline;
+  padding: 0;
+  margin: 0 0 10px;
+}
+.contao-cookiebar .cc-detail-btn-details span:nth-child(2) {
+  display: none;
+}
+.contao-cookiebar .cc-detail-btn-details.cc-active span:nth-child(1) {
+  display: none;
+}
+.contao-cookiebar .cc-detail-btn-details.cc-active span:nth-child(2) {
+  display: inline;
+}
+.contao-cookiebar .cc-detail-btn-details:hover {
+  color: #717171;
+}
+.contao-cookiebar .cc-info {
+  margin-top: 15px;
+}
+.contao-cookiebar .cc-info > p {
+  font-size: 0.875rem;
+}
+.contao-cookiebar .cc-info > a {
+  display: inline-block;
+  font-size: 0.813rem;
+  color: #a2a2a2;
+  text-decoration: none;
+}
+.contao-cookiebar .cc-info > a:hover {
+  color: #717171;
+}
+.contao-cookiebar .cc-info > a + a:before {
+  display: inline-block;
+  content: "·";
+  margin-right: 5px;
+}


### PR DESCRIPTION
This fixes the issue that the cookiebar is not displayed in the viewport if its width is 100% of the available space.
This is caused because the ::before pseudo element, although it has no width, appears to take up 1px in width, which causes the .cc-inner to wrap under the pseudo element.
<img width="596" alt="Bildschirmfoto 2024-04-18 um 13 09 14" src="https://github.com/oveleon/contao-cookiebar/assets/42083846/86713129-6076-48c8-b65d-f7a24d480857">

These changes probably should also be applied to the 2.x branch.

EDIT: This only seems to occur if a non-zero word-spacing is set for example on the body. Still shouldn't happen in that case IMO.