### PR TITLE
Properly load google consent mode in 1.x

### DIFF
--- a/src/Resources/contao/classes/CookieConfig.php
+++ b/src/Resources/contao/classes/CookieConfig.php
@@ -131,6 +131,13 @@ class CookieConfig extends AbstractCookie
      */
     private function compileTagManager()
     {
+        # Determine the G-ID to ensure the opt-out (#127)
+        $this->addScript(
+            "window.addEventListener('gtm_loaded', () => { setTimeout(() => { const gid = Object.keys(window.google_tag_manager).filter(k => k.startsWith('G-'))[0]; try{ if(gid){ window['ga-disable-' + gid] = true; }   }catch(e){}}, 1000)});",
+            self::LOAD_ALWAYS,
+            self::POS_HEAD
+        );
+
         $this->addScript(
             "(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','" . $this->vendorId . "');",
             self::LOAD_ALWAYS,

--- a/src/Resources/contao/classes/CookieConfig.php
+++ b/src/Resources/contao/classes/CookieConfig.php
@@ -131,10 +131,10 @@ class CookieConfig extends AbstractCookie
      */
     private function compileTagManager()
     {
-        $this->addResource(
-            'https://www.googletagmanager.com/gtag/js?id=' . $this->vendorId,
-            ['async'],
-            self::LOAD_ALWAYS
+        $this->addScript(
+            "(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','" . $this->vendorId . "');",
+            self::LOAD_ALWAYS,
+            self::POS_HEAD
         );
 
         if($src = $this->scriptConfig)


### PR DESCRIPTION
This fixes a regression from implementing the google consent mode in the old 5.x-branch that has never been down-streamed into the 1.x branch.

As discussed with @zoglo , this needs to be partially upstreamed into 2.x due to the loading order of the `compileConsentMode()` function.