### PR TITLE
Remove switchToEdit from tl_cookie and tl_cookie_config DCA config

### DIFF
--- a/contao/dca/tl_cookie.php
+++ b/contao/dca/tl_cookie.php
@@ -297,7 +297,6 @@ $GLOBALS['TL_DCA']['tl_cookie'] = [
     'config' => [
         'dataContainer'               => DC_Table::class,
         'ptable'                      => 'tl_cookie_group',
-        'switchToEdit'                => true,
         'enableVersioning'            => true,
         'markAsCopy'                  => 'title',
         'sql' => [

--- a/contao/dca/tl_cookie_config.php
+++ b/contao/dca/tl_cookie_config.php
@@ -129,7 +129,6 @@ $GLOBALS['TL_DCA']['tl_cookie_config'] = [
     // Config
     'config' => [
         'dataContainer'               => DC_Table::class,
-        'switchToEdit'                => true,
         'enableVersioning'            => true,
         'markAsCopy'                  => 'title',
         'sql' => [


### PR DESCRIPTION
If switchToEdit is enabled for a DCA Contao will show a "Save and edit child elements" button. This does not make sense for tl_cookie and tl_cookie_config since those can't have any child elements. This behaviour is fixed by removing the setting.

If one would click on the button the following empty page appears.
<img width="1655" alt="Bildschirmfoto 2024-06-19 um 13 34 07" src="https://github.com/oveleon/contao-cookiebar/assets/42083846/36164e13-6b6f-4b91-a13a-eb6447363ff2">
<img width="1660" alt="Bildschirmfoto 2024-06-19 um 13 34 01" src="https://github.com/oveleon/contao-cookiebar/assets/42083846/f892305b-1de0-44b8-8da0-dacec1adba94">
