### PR TITLE
Handle protocol in `MatomoTagManager` vendorUrl dynamically

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     "symfony/dependency-injection": "~4.4.23 || ^5.4",
     "symfony/framework-bundle": "4.4.* || ^5.4",
     "symfony/http-kernel": "4.4.* || ^5.4",
-    "symfony/routing": "4.4.* || ^5.4"
+    "symfony/routing": "4.4.* || ^5.4",
+    "symfony/polyfill-php80": "*"
   },
   "require-dev": {
     "contao/manager-plugin": "^2.0",

--- a/src/Resources/contao/classes/CookieHandler.php
+++ b/src/Resources/contao/classes/CookieHandler.php
@@ -292,7 +292,7 @@ class CookieHandler extends AbstractCookie
      */
     private function compileMatomo()
     {
-        $url = substr($this->vendorUrl, -1) === '/' ? $this->vendorUrl : $this->vendorUrl . '/';
+        $url = str_ends_with($this->vendorUrl, '/') ? $this->vendorUrl : $this->vendorUrl . '/';
 
         $this->addScript(
             "var _paq = window._paq = window._paq || []; " . ($this->scriptConfig ?: "_paq.push(['trackPageView']); _paq.push(['enableLinkTracking']);") . " (function() { var u='" . $url . "'; _paq.push(['setTrackerUrl', u+'matomo.php']); _paq.push(['setSiteId', " . $this->vendorId . "]); var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);})();",
@@ -316,10 +316,15 @@ class CookieHandler extends AbstractCookie
             );
         }
 
-        $url = substr($this->vendorUrl, -1) === '/' ? $this->vendorUrl : $this->vendorUrl . '/';
+        $url = str_ends_with($this->vendorUrl, '/') ? $this->vendorUrl : $this->vendorUrl . '/';
+
+        if (!str_starts_with($url, 'http')) 
+        {
+            $url = 'https://'.$url;
+        }
 
         $this->addScript(
-            " var _mtm = window._mtm = window._mtm || []; _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'}); var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.async=true; g.src='https://".$url."js/container_".$this->vendorId.".js'; s.parentNode.insertBefore(g,s);",
+            " var _mtm = window._mtm = window._mtm || []; _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'}); var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.async=true; g.src='".$url."js/container_".$this->vendorId.".js'; s.parentNode.insertBefore(g,s);",
             self::LOAD_CONFIRMED,
             self::POS_HEAD
         );

--- a/src/Resources/contao/classes/CookieHandler.php
+++ b/src/Resources/contao/classes/CookieHandler.php
@@ -318,7 +318,7 @@ class CookieHandler extends AbstractCookie
 
         $url = str_ends_with($this->vendorUrl, '/') ? $this->vendorUrl : $this->vendorUrl . '/';
 
-        if (!str_starts_with($url, 'http')) 
+        if (!str_starts_with($url, 'http'))
         {
             $url = 'https://'.$url;
         }

--- a/src/Resources/contao/dca/tl_cookie.php
+++ b/src/Resources/contao/dca/tl_cookie.php
@@ -311,7 +311,8 @@ $GLOBALS['TL_DCA']['tl_cookie'] = array
             'eval'                    => array('rgxp'=>'httpurl', 'mandatory'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
             'sql'                     => "varchar(255) NOT NULL default ''",
             'load_callback'           => array(
-                array('tl_cookie', 'overwriteTranslation')
+                array('tl_cookie', 'overwriteTranslation'),
+                array('tl_cookie', 'updateProtocolRegex')
             )
         ),
         'description' => array
@@ -711,6 +712,24 @@ class tl_cookie extends Contao\Backend
         if ('googleConsentMode' === $dc->activeRecord->type)
         {
             $GLOBALS['TL_DCA']['tl_cookie']['fields'][$dc->field]['eval']['mandatory'] = false;
+        }
+
+        return $varValue;
+    }
+
+    /**
+     * Removes the protocol regex
+     *
+     * @param $varValue
+     * @param $dc
+     *
+     * @return mixed
+     */
+    public function updateProtocolRegex($varValue, $dc)
+    {
+        if ('matomoTagManager' === $dc->activeRecord->type)
+        {
+            unset($GLOBALS['TL_DCA']['tl_cookie']['fields'][$dc->field]['eval']['rgxp']);
         }
 
         return $varValue;


### PR DESCRIPTION
Changed wrong protocol for MatomoTagManager cookie (closes #226) and added `symfony/polyfill-php80` for better upstream compatibilty.