### PR TITLE
Fix a PHP 8 warning in `tl_cookie.php`

### DIFF
--- a/src/Resources/contao/dca/tl_cookie.php
+++ b/src/Resources/contao/dca/tl_cookie.php
@@ -691,7 +691,7 @@ class tl_cookie extends Contao\Backend
     {
         $field = $dc->activeRecord->type . '_' . $dc->field;
 
-        if($tl = $GLOBALS['TL_LANG']['tl_cookie'][$field])
+        if($tl = ($GLOBALS['TL_LANG']['tl_cookie'][$field] ?? null))
         {
             $GLOBALS['TL_DCA']['tl_cookie']['fields'][$dc->field]['label'] = $tl;
         }


### PR DESCRIPTION
Fixes the following warning:

```
ErrorException:
Warning: Undefined array key "matomo_scriptConfig"

  at vendor\oveleon\contao-cookiebar\src\Resources\contao\dca\tl_cookie.php:694
  at tl_cookie->overwriteTranslation()
     (vendor\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:1971)
  at Contao\DC_Table->edit()
     (vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:667)
  at Contao\Backend->getBackendModule()
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor\contao\core-bundle\src\Controller\BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor\symfony\http-kernel\HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor\symfony\http-kernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (web\index.php:44)
```