### PR TITLE
Fix: exclude ContaoManager dir with Plugin class from services

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,7 +6,7 @@ services:
 
     Oveleon\ContaoCookiebar\:
         resource: '../src/'
-        exclude: '../src/{Model,DependencyInjection,Resources,AbstractCookie.php,ContaoCookiebar.php,Cookiebar.php,GlobalConfig.php,Cookie.php}'
+        exclude: '../src/{ContaoManager,Model,DependencyInjection,Resources,AbstractCookie.php,ContaoCookiebar.php,Cookiebar.php,GlobalConfig.php,Cookie.php}'
 
     Oveleon\ContaoCookiebar\EventListener\KernelRequestListener:
         arguments:


### PR DESCRIPTION
Resolves error when using bundle for non-managed Contao:
In DefinitionErrorExceptionPass.php line 51:
Class "Contao\ManagerPlugin\Bundle\BundlePluginInterface" not found while loading "Oveleon\ContaoCookiebar\ContaoManager\Plugin".