### PR TITLE
force array to return

### DIFF
--- a/src/Resources/contao/classes/CookieHandler.php
+++ b/src/Resources/contao/classes/CookieHandler.php
@@ -257,7 +257,7 @@ class CookieHandler extends AbstractCookie
             }
         }
 
-        if (!empty($modes = StringUtil::deserialize($this->gcmMode)))
+        if (!empty($modes = StringUtil::deserialize($this->gcmMode, true)))
         {
             $consent = "gtag('consent', 'update', { " . implode(', ', array_map(fn ($mode) => "'$mode':'granted'", $modes)) . " });";
             $script = $gtagInit . $consent;


### PR DESCRIPTION
Rückgabewert muss als array sein
```
[2024-12-19T12:58:45.373884+01:00] php.CRITICAL: Uncaught Error: array_map(): Argument #2 ($array) must be of type array, string given {"exception":"[object] (TypeError(code: 0): array_map(): Argument #2 ($array) must be of type array, string given at /html/live/vendor/oveleon/contao-cookiebar/src/Resources/contao/classes/CookieHandler.php:262)"} []
[2024-12-19T12:58:45.375876+01:00] request.CRITICAL: Uncaught PHP Exception TypeError: "array_map(): Argument #2 ($array) must be of type array, string given" at /html/live/vendor/oveleon/contao-cookiebar/src/Resources/contao/classes/CookieHandler.php line 262 {"exception":"[object] (TypeError(code: 0): array_map(): Argument #2 ($array) must be of type array, string given at /html/live/vendor/oveleon/contao-cookiebar/src/Resources/contao/classes/CookieHandler.php:262)"} []
```