### PR TITLE
use `FrontendTemplate` instead of `BackendTemplate`

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -9,9 +9,9 @@
  */
 
 namespace Oveleon\ContaoCookiebar;
-
-use Contao\BackendTemplate;
 use Contao\Environment;
+
+use Contao\FrontendTemplate;
 use Contao\StringUtil;
 use Contao\System;
 use Oveleon\ContaoCookiebar\Model\CookieModel;
@@ -173,7 +173,7 @@ class Cookie extends AbstractCookie
      */
     private function addCustomTemplate(): void
     {
-        $objTemplate = new BackendTemplate($this->scriptTemplate);
+        $objTemplate = new FrontendTemplate($this->scriptTemplate);
         $strTemplate = $objTemplate->parse();
 
         if (empty($strTemplate)) {


### PR DESCRIPTION
When using a cookie of type "Script (Template)" a `BackendTemplate` instance is used to render it - even though the template is only ever rendered in the _front_ end. This means that many methods are missing for the template, e.g. you would not be able to use `$this->hasAuthenticatedBackendUser()`.

Was there a particular reason to use `BackendTemplate` instead of `FrontendTemplate`?