### PR TITLE
Unlock `doctrine/dbal` ^4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "contao/core-bundle": "^5.3",
         "symfony/http-foundation": "^6.4 || ^7.0",
         "symfony/config": "^6.4 || ^7.0",
-        "doctrine/dbal": "^3.6",
+        "doctrine/dbal": "^3.6 || ^4.3",
         "symfony/console": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",
         "symfony/http-kernel": "^6.4 || ^7.0",


### PR DESCRIPTION
### Description

Allows `doctrine/dbal` in ^4.3 (there is no need for migrations nor changes in the CCB)